### PR TITLE
Improve verbosity when connecting in verbose mode

### DIFF
--- a/mcv/remote/__init__.py
+++ b/mcv/remote/__init__.py
@@ -41,7 +41,11 @@ def connection(connspec, verbose=False):
     host = connspec.pop('host', None)
 
     if verbose:
-        sys.stderr.write("Connecting...")
+        sys.stderr.write(
+                "Connecting to {user}@{host}:{port}...".format(
+                user=connspec['username'],
+                host=host,
+                port=connspec['port']))
 
     ssh.connect(host, **connspec)
 


### PR DESCRIPTION
Now in verbose mode, `mcv.remote.connection` will tell you
to where it's connecting (what user, host, port).  This is
useful for knowing what's going on.
