### PR TITLE
Enable pip install --upgrade

### DIFF
--- a/mcv/pip.py
+++ b/mcv/pip.py
@@ -14,15 +14,21 @@ def status(pkgs):
     installed = _status(out)
     return { p:installed.get(p) for p in pkgs }
 
-def _install(pkgs):
+def _install_cmd(pkgs, upgrade=False):
     if not pkgs:
-        return True
+        return None
 
-    cmd = [pip_cmd, 'install'] + pkgs
-    retval = subprocess.call(cmd, stdout=sys.stdout, stderr=sys.stderr)
-    return retval
+    opt_upgrade = ['--upgrade'] if upgrade else []
+
+    return [pip_cmd, 'install'] + opt_uprade + pkgs
 
 def install(pkgs):
     installed_packages = status(pkgs)
     pkgs_to_install = [p for p in pkgs if not installed_packages[p]]
-    return _install(pkgs_to_install)
+
+    cmd = _install_cmd(pkgs_to_install, upgrade=upgrade)
+
+    if cmd:
+        return subprocess.call(cmd, stdout=sys.stdout, stderr=sys.stderr)
+    else:
+        return None

--- a/mcv/remote/pip.py
+++ b/mcv/remote/pip.py
@@ -11,15 +11,13 @@ def status(ssh, pkgs):
     installed = mcv.pip._status(out)
     return { p:installed.get(p) for p in pkgs }
 
-def _install(ssh, pkgs, sudo=False, verbose=False):
-    if not pkgs:
-        return True
-
-    cmd = [pip_cmd, 'install'] + pkgs
-
-    return mcv.remote.execute(ssh, cmd, sudo=sudo, verbose=verbose)
-
-def install(ssh, pkgs, sudo=False, verbose=False):
+def install(ssh, pkgs, sudo=False, verbose=False, upgrade=False):
     installed_packages = status(ssh, pkgs)
     pkgs_to_install = [p for p in pkgs if not installed_packages[p]]
-    return _install(ssh, pkgs_to_install, sudo=sudo, verbose=verbose)
+
+    cmd = mcv.pip._install_cmd(pkgs_to_install, upgrade=upgrade)
+
+    if cmd:
+        return mcv.remote.execute(ssh, cmd, sudo=sudo, verbose=verbose)
+    else:
+        return None


### PR DESCRIPTION
This commit adds a flag to the local and remote `pip` modules that
allow you to run `pip install --upgrade` either locally or remotely.

In the course of the doing this, it consolidates the command
generation a bit, since it's the same command regardless of whether
it's executed locally via `subprocess` or remotely via `mcv.remote`.
Thus we now have one function `mcv.pip._install_cmd` that is used
by both local and remote modules.

Having this functionality allows you to force upgrading `pip` packages
even if the system thinks you already have an existing (old) version.
