### PR TITLE
Document passing private key to mcv.remote.connection

### DIFF
--- a/mcv/remote/__init__.py
+++ b/mcv/remote/__init__.py
@@ -24,6 +24,7 @@ def connection(connspec, verbose=False):
     - host
     - port
     - username (default: getpass.getuser())
+    - key_file (path to private key)
 
     As well as 'extended' configuration for Paramiko:
     - missing_host_key_policy


### PR DESCRIPTION
This commit adds a comment explaining how to pass a private key file
to mcv.remote.connection (thus/the same way as passing it to the
underlying Paramiko).

This is helpful when you want to specify a private key.  This is
particularly useful/necessary for connecting to a Vagrant instance.
