### PR TITLE
Add basic idempotent file operations module

### DIFF
--- a/mcv/file.py
+++ b/mcv/file.py
@@ -1,0 +1,43 @@
+"""OS Manipulation
+
+Wrappers around os, os.path"""
+
+from __future__ import absolute_import
+
+import os
+import mcv.user
+import grp
+
+def chmod(path, mode):
+    if not mode:
+        return
+
+    os.chmod(path, mode)
+
+def chown(path, owner=None, group=None):
+    if owner:
+        uid = mcv.user.ent_passwd(owner)['uid'] \
+            if isinstance(owner, basestring) \
+            else owner
+        os.chown(path, uid, -1)
+
+    if group:
+        gid = grp.getgrnam(group).gr_gid \
+            if isinstance(group, basestring) \
+            else group
+        os.chown(path, -1, gid)
+
+def mkdir(path, opts={}):
+    """Idempotent mkdir
+    
+    opts={
+        'owner': 'johndoe',
+        'group': 'framed',
+        'mode': '02775'
+    })
+    """
+    if not os.path.exists(path):
+        os.mkdir(path, mode)
+
+    chmod(path, opts.get('mode'))
+    chown(path, opts.get('owner'), opts.get('group'))


### PR DESCRIPTION
This commit adds a basic module with a few idempotent file
operations:
- mkdir
- chown
- chmod

Mkdir composes/accepts ownership/group ownership/mode options
so as to conveniently set the state of the directory that got made:

mkdir("/foo/bar", {
  'owner': 'elliot',
  'group': 'framed',
  'mode': '02775'
})
