### PR TITLE
Avoid path joining in mcv.git.export

### DIFF
--- a/mcv/git.py
+++ b/mcv/git.py
@@ -52,11 +52,7 @@ def fetch(repo_path, key_path):
 def current_rev(repo_path):
     return subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=repo_path).strip()
 
-def export(repo_path, deploy_root, rev, opts={'mode': 0777}):
-    mcv.file.mkdir(deploy_root, opts=opts)
-
-    deploy_path = os.path.join(deploy_root, rev)
-
+def export(repo_path, deploy_path, rev, opts={'mode': 0777}):
     if not os.path.exists(deploy_path):
         mcv.file.mkdir(deploy_path, opts=opts)
 


### PR DESCRIPTION
Prior to this commit, mcv.git.export would attempt to be "smart" about
constructing paths, by having default assumptions about where exported
snapshots of git repos would go.  This is not a good strategy--let the
caller handle all the logic of where the output is going to go, rather
than having an inflexible assumption, and just put the output where
it's asked to.

This commit removes the path joining logic and just puts the output
where requested.
