### PR TITLE
Enabling passing SSH options to git commands

### DIFF
--- a/mcv/git.py
+++ b/mcv/git.py
@@ -6,14 +6,29 @@ import sys
 import subprocess
 import tempfile
 from contextlib import contextmanager
+import itertools
+
+def lines_to_string(lines):
+    return "".join(" ".join(l) + "\n" for l in lines)
 
 @contextmanager
-def git_ssh_env(key_path):
+def git_ssh_env(key_path, opts={}):
     """Return an environment dictionary that has been setup with
     the proper GIT_SSH set to enable git commands with SSH configured
-    properly."""
+    properly.
+
+    Takes a path to an SSH private key,
+    and a dictionary opts={} which contains SSH -o options,
+    as explained in man pages for ssh_config(5)
+    """
+    opt_pairs = [['-o', "{}={}".format(k, v)] for k, v in opts.iteritems()]
+    opts_chained = [o for o in itertools.chain(*opt_pairs)]
+
+    temp_ssh_script = lines_to_string(
+        [["#!/bin/sh"],
+         ["exec", "/usr/bin/ssh", "-i", key_path] + opts_chained + ["\"$@\""]])
     with tempfile.NamedTemporaryFile(delete=False) as f:
-        f.write("#!/bin/sh\nexec /usr/bin/ssh -i {} \"$@\"\n".format(key_path))
+        f.write(temp_ssh_script)
     mcv.file.chmod(f.name, 0700)
     env = os.environ.copy()
     env['GIT_SSH'] = f.name
@@ -35,13 +50,21 @@ def repo_exists(path, verbose='error'):
                 stderr=stderr)
     return retval == 0
 
-def clone(repo_url, repo_path, key_path):
+def clone(repo_url, repo_path, key_path, ssh_opts={}):
+    """Clone git repo from remote `repo_url` to local `repo_path`
+
+    Takes a path to an SSH private key file, and an dictionary
+    of ssh -o options, as explained in man for ssh_config(5)"""
     if not repo_exists(repo_path):
-        with git_ssh_env(key_path) as env:
+        with git_ssh_env(key_path, opts=ssh_opts) as env:
             retval = subprocess.call(['git', 'clone', repo_url, repo_path], env=env)
 
-def fetch(repo_path, key_path):
-    with git_ssh_env(key_path) as env:
+def fetch(repo_path, key_path, ssh_opts={}):
+    """Fetch a local git repo at path `repo_path`
+
+    Takes a path to an SSH private key file, and an dictionary
+    of ssh -o options, as explained in man for ssh_config(5)"""
+    with git_ssh_env(key_path, opts=ssh_opts) as env:
         return subprocess.call(
             ['git', 'fetch'],
             cwd=repo_path,
@@ -50,9 +73,13 @@ def fetch(repo_path, key_path):
             env=env)
 
 def current_rev(repo_path):
+    """Return the current revision of the repo at local `repo_path`"""
     return subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=repo_path).strip()
 
 def export(repo_path, deploy_path, rev, opts={'mode': 0777}):
+    """Export a copy of the contents of the git repo
+    from local `repo_path` at revision `rev` to the local
+    directory `deploy_path`.  Does not include the git metadata."""
     if not os.path.exists(deploy_path):
         mcv.file.mkdir(deploy_path, opts=opts)
 


### PR DESCRIPTION
Prior this commit there was only very limited control one had
over SSH options in the `mcv.git` module.  This commit makes it so
that you can pass any SSH -o option (see `man ssh_config 5`) to the
`mcv.git` commands in the `ssh_opts` dictionary and get that SSH
behavior.

Example:

```
import mcv.git
mcv.git.clone(
    'git@github.com:framed-data/mcv.git',
    '/home/me/mcv',
    '/home/me/.ssh/id_rsa',
    {'StrictHostKeyChecking': 'no'})
```

Currently the args are all strings and need to exactly match what the
ssh shell command expects (e.g. 'yes', 'no')--there's no conversion
between Pythonic values like True/False to those strings.
