### PR TITLE
Add directory tree listing, subpathing

### DIFF
--- a/mcv/dir.py
+++ b/mcv/dir.py
@@ -1,0 +1,104 @@
+"""Directory operations
+
+A thin wrapper on top of treant
+
+For the sake of clarity, we'll keep the term `path` reserved for
+directory paths, and we'll call treant tree paths `tpath`s.
+
+This module should mostly expose things in terms of `path`s, not
+`tpaths`, though it should be possible to drop down to the lower
+level  if necessary.
+"""
+
+import treant
+import os
+import mcv.file, mcv.util
+
+def tree(node):
+    """Construct a tree from nodes; use the treant 'smart' node
+    constructor with flexible tuple interpretation:
+
+    (value)
+    (value, <[list-is-children]>)
+    (value, <{dict-is-attributes}>)
+    (value, <[list-is-children]>, <{dict-is-attributes}>)
+    (value, <{dict-is-attributes}>, <[list-is-children]>)
+    """
+    return treant.tree(node, node_constructor=treant.n)
+
+def _path(tree_path):
+    """Given a tree path returns its directory path.
+
+    - Treepath = [<root_node>, <home_node>, <john_node>]
+    - Directory path => "/home/john"
+    """
+    # convert nodes e.g. [<root_node>, <home_node>, <john_node>]
+    # to their values, e.g. ["/", "home", "john"]
+    tpath_values = [treant.value(node) for node in tree_path]
+    return os.path.join(*tpath_values)
+
+def _opts(tree_path):
+    """Given a tree path return its computed opts.  Opts
+    merge hierarchically, combining and overriding
+    down the hierarchy.
+
+    - Treepath = [<home_node, opts={'group': 'mycompany', 'mode': 02755}>,
+                  <john_node, opts={'owner': 'john'}>,
+                  <public_node, opts={'mode': 02775}>]
+    - opts => {'owner': 'john',
+               'group': 'mycompany',
+               'mode': 02775}
+   """
+    tpath_opts = [treant.attrs(node) for node in tree_path]
+    return mcv.util.merge_dicts(*tpath_opts)
+
+def subpath(tree, search_name, *subpaths):
+    """Find a node in the tree and return a subpath thereof.
+
+    Given a tree corresponding to:
+
+    - /foos
+      - bar
+      - baz
+        - quux
+
+        tree = <setup the above>
+
+        subpath(tree, 'quux', 'fizz', buzz')
+        # => "/foo/baz/quux/fizz/buzz"
+
+        subpath(tree, 'nonsense!', 'fizz', buzz')
+        # => None #; if the search fails, don't subpath.
+    """
+    # get the path values themselves out of the tpath, not the full nodes
+    root_tpath = treant.find_path_ex(tree, lambda n: treant.value(n) == search_name)
+
+    if not root_tpath:
+        return None
+
+    return os.path.join(*[_path(root_tpath)] + [p for p in subpaths])
+
+def paths(tree):
+    # list of tpaths, i.e. list of (list of nodes)
+    tps = [tp for tp in treant.paths_preorder(tree)]
+    return [_path(tp) for tp in tps]
+
+def _mktree(tree):
+    """Given a tree, return a list of (path, opts) tuples
+    with opts applied hiearchically, i.e. opts specified at a node
+    also get applied to subnodes (unless later overridden)"""
+    tps = [tp for tp in treant.paths_preorder(tree)]
+
+    # construct two parallel lists: paths, and opts of each path
+    paths = [_path(tp) for tp in tps]
+    opts = [_opts(tp) for tp in tps]
+
+    return zip(paths, opts)
+
+def mktree(tree):
+    """Given a tree, make all the directories in the tree
+    recursively, with opts applied hiearchically, i.e. opts specified
+    at a node also get applied to subnodes (unless later
+    overridden)"""
+    for path, opts in _mktree(tree):
+        mcv.file.mkdir(path, opts=opts)

--- a/mcv/file.py
+++ b/mcv/file.py
@@ -10,6 +10,8 @@ import grp
 import subprocess
 import tempfile
 
+opt_keys = ['owner', 'group', 'mode']
+
 def chmod(path, mode, recursive=False):
     if not mode:
         return

--- a/mcv/util.py
+++ b/mcv/util.py
@@ -1,0 +1,13 @@
+"""General utilities for mcv"""
+
+import itertools
+
+def select_keys(d, keys):
+    return { k:d.get(k) for k in keys if d.get(k) }
+
+def merge_dicts(*ds):
+    """Takes multiple dicts and shallowly merges their KV
+    pairs.  KVs in later dicts replace the same K in earlier
+    dicts."""
+    d_lists = map(lambda d: d.items(), ds)
+    return dict([i for i in itertools.chain(*d_lists)])

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,14 @@
 from setuptools import setup, find_packages
 setup(
     name = "mcv",
-    version = "0.4.0",
+    version = "0.5.0",
     packages = find_packages(),
     install_requires = [
         'pyyaml',
         'labrador',
-        'paramiko'],
+        'paramiko',
+        'treant',
+        'nose'],
     author = "Elliot Block",
     author_email = "elliot@framed.io",
     description = "Spartan configuration management in Python",

--- a/tests/test_dir.py
+++ b/tests/test_dir.py
@@ -1,0 +1,55 @@
+"""Tests for mcv.dir module"""
+
+import mcv.dir
+from nose.tools import eq_
+
+tree0 = mcv.dir.tree(
+    ('/', [
+         ('opt', [
+             ('framed', [
+                 ('bin')]),
+             ('mcv', [
+                 ('bin'),
+                 ('tests')])])]))
+
+framed_attrs = {
+    'group': 'framed',
+    'mode': 02775,
+}
+
+tree1 = mcv.dir.tree(
+    ('/', [
+         ('opt', [
+             ('framed', framed_attrs, [
+                 ('bin'),
+                 ('public', { 'mode': 0777 })]),
+             ('mcv', framed_attrs, [
+                 ('bin') ])])]))
+
+def test_subpath_hit():
+    eq_(mcv.dir.subpath(tree0, 'framed', 'src'),
+        "/opt/framed/src")
+
+def test_subpath_miss():
+    eq_(mcv.dir.subpath(tree0, 'nonsense!', 'src'), None)
+
+def test_paths():
+    eq_(mcv.dir.paths(tree0),
+        ['/',
+         '/opt',
+         '/opt/framed',
+         '/opt/framed/bin',
+         '/opt/mcv',
+         '/opt/mcv/bin',
+         '/opt/mcv/tests'])
+
+def test__mktree():
+    eq_(mcv.dir._mktree(tree1),
+        [("/", {}),
+         ("/opt", {}),
+         ("/opt/framed", framed_attrs),
+         ("/opt/framed/bin", framed_attrs),
+         ("/opt/framed/public", { 'group': 'framed', 'mode': 0777 }),
+         ("/opt/mcv", framed_attrs),
+         ("/opt/mcv/bin", framed_attrs)])
+

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,24 @@
+import mcv.util
+from nose.tools import eq_
+
+def test_select_keys_hit():
+    d = { 'foo': 20, 'bar': 40 }
+
+    eq_(mcv.util.select_keys(d, ['foo']),
+        {'foo': 20})
+
+def test_select_keys_miss():
+    d = { 'foo': 20, 'bar': 40 }
+
+    eq_(mcv.util.select_keys(d, ['foo', 'baz']),
+        {'foo': 20})
+
+def test_merge_dicts():
+    d0 = { 'foo': 20, 'bar': 40 }
+    d1 = { 'baz': 60 }
+    d2 = { 'foo': 30 }
+
+    eq_(mcv.util.merge_dicts(d0, d1, d2),
+        { 'foo': 30,
+          'bar': 40,
+          'baz': 60 })


### PR DESCRIPTION
This commit adds some basic directory-tree operations, based
on `treant`:

You can define your path hierarchy that you want:

```
tree = mcv.dir.tree(
  ('/', [
    ('opt', [
        ('framed', [
            ('bin')]),
        ('mcv', [
            ('bin'),
            ('tests')])])]))
```

Then you can get the most common operations out of it, e.g.
1. Create all the directories `mktree()`
2. Find a node in the tree, and subpath therefrom `subpath()`
