### PR TITLE
Tighten `mcv.git.export()` options

### DIFF
--- a/mcv/git.py
+++ b/mcv/git.py
@@ -76,14 +76,20 @@ def current_rev(repo_path):
     """Return the current revision of the repo at local `repo_path`"""
     return subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=repo_path).strip()
 
-def export(repo_path, deploy_path, rev, opts={'mode': 0777}):
+def export(repo_path, deploy_path, rev, opts={}):
     """Export a copy of the contents of the git repo
     from local `repo_path` at revision `rev` to the local
     directory `deploy_path`.  Does not include the git metadata."""
     if not os.path.exists(deploy_path):
-        mcv.file.mkdir(deploy_path, opts=opts)
+        mcv.file.mkdir(
+            deploy_path,
+            opts={'parents': opts.get('parents', True)})
 
         cmd = "git archive {rev} | tar -x -C {dir}".format(rev=rev, dir=deploy_path)
         out = subprocess.check_output(cmd, cwd=repo_path, shell=True)
-        mcv.file.ch_ext(deploy_path, opts)
+        mcv.file.ch_ext(
+            deploy_path,
+            mcv.util.merge_dicts(
+                { 'recursive': True },
+                mcv.util.select_keys(opts, ['owner', 'group'])))
         return out


### PR DESCRIPTION
Prior to this commit the directory creation/permissions/ownership
options in `mcv.git.export()` were pretty loose/incorrect.  For
example the procedure would overwrite all the repo file permissions
when really it shouldn't be touching the file permissions (which
are known/saved into git), though it should _consider_ changing the
ownership permissions.  This commit corrects several of the
situations:
- the `parents` key controls whether it'll create any prerequisite
  path directories up to requested export path.  This key will
  only be relevant during initial target directory setup and
  will default to `True`
- the `mode` key controls _only_ the mode of any prereq directories/
  the target export destination directory itself but not the files
  within it--those are controlled by git.
- the `owner` key controls the file ownership for any prereq
  directories _as well as_ files within the deployed repo themselves.
- the `group` key functions the same as the `owner` key above
- the `recursive` key is ignored; the mode opts are applied exactly
  once  to the target deploy directory after it's created and empty
  (and thus `recursive` doesn't mean anything), and then it's
  _always_ applied to all the files instead the deploy directory
  once the files have been unarchived it.  So this flag is ignored
  if passed.

There's currently an issue with all cases of:

```
mcv.file.mkdir(..., {'parents': True})
```

which includes the usage that this function `mcv.git.export()` does,
which is that if it has to create multiple parents `/opt/foo/bar/baz`
then the specified ownership/permission options are only applied to
the leaf node, and not the entire chain that got there.  This is good
because you don't want to recursively overwrite all the perms in
`/opt`, but bad because you probably did want to affect `foo/bar/baz`.

There's not a resolution to this yet but that resolution should be
general to `mcv.file.mkdir()` and then this function would follow
suite.
