### PR TITLE
Enable streaming output from mcv.remote.execute

### DIFF
--- a/mcv/remote/apt.py
+++ b/mcv/remote/apt.py
@@ -3,32 +3,27 @@ import mcv.apt
 
 import sys
 
-def _status(ssh, pkg, verbose=False):
+def _status(ssh, pkg):
     raw_out, err, exit = mcv.remote.execute(ssh, mcv.apt._dpkg_query_cmd(pkg))
     out = raw_out + "\n" # dpkg output by default has no newline
 
-    if verbose == True or (verbose == 'error' and exit != 0):
-        sys.stdout.write(out)
-        sys.stderr.write(err)
-
     return mcv.apt._dpkg_status(out)
 
-def status(ssh, pkgs, verbose=False):
-    return { p:_status(ssh, p, verbose=verbose) for p in pkgs }
+def status(ssh, pkgs):
+    return { p:_status(ssh, p) for p in pkgs }
 
-def _install(ssh, pkgs, verbose='error'):
+def _install(ssh, pkgs):
     if not pkgs:
         return (None, None, None)
 
     return mcv.remote.execute(
         ssh,
         [mcv.apt.apt_cmd, 'install', '-y'] + pkgs,
-        sudo=True,
-        verbose=verbose)
+        sudo=True)
 
-def install(ssh, pkgs, verbose='error'):
+def install(ssh, pkgs):
     installed_packages = status(ssh, pkgs)
     pkgs_to_install = [p for p in pkgs if not installed_packages[p]]
 
-    return _install(ssh, pkgs_to_install, verbose=verbose)
+    return _install(ssh, pkgs_to_install)
 

--- a/mcv/remote/pip.py
+++ b/mcv/remote/pip.py
@@ -11,13 +11,13 @@ def status(ssh, pkgs):
     installed = mcv.pip._status(out)
     return { p:installed.get(p) for p in pkgs }
 
-def install(ssh, pkgs, sudo=False, verbose=False, upgrade=False):
+def install(ssh, pkgs, sudo=False, upgrade=False):
     installed_packages = status(ssh, pkgs)
     pkgs_to_install = [p for p in pkgs if not installed_packages[p]]
 
     cmd = mcv.pip._install_cmd(pkgs_to_install, upgrade=upgrade)
 
     if cmd:
-        return mcv.remote.execute(ssh, cmd, sudo=sudo, verbose=verbose)
+        return mcv.remote.execute(ssh, cmd, sudo=sudo)
     else:
         return None

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 setup(
     name = "mcv",
-    version = "0.5.1",
+    version = "0.6.0",
     packages = find_packages(),
     install_requires = [
         'pyyaml',


### PR DESCRIPTION
This commit makes it possible to stream stdout/stderr from remote
commands while they're happening.  This is essential from long-running
remote commands, and commands where the you can't tell if the remote
command has hung/failed; you want to see the output as it's happening.

Unfortunately this messes up the old verbosity behavior; you don't
want to have to wait until a command has fail-exited to see its
output.  So now if you want to control verbosity you have to pass in
alternate stdout/stderr handles _beforehand_, to handle the streams of
output that may or may not occur.  This is a fine/normal tradeoff
for now; it works just the same as normal local commands, which need
to make the same tradeoff anyway.
