### PR TITLE
Enable remotely `apt-get update`ing a box

### DIFF
--- a/mcv/apt.py
+++ b/mcv/apt.py
@@ -4,6 +4,7 @@ import re
 import os
 
 apt_cmd = "/usr/bin/apt-get"
+update_cmd = [apt_cmd, 'update']
 
 # Some of the dpkg facilities are factored out so that they're usable
 # both locally here and remotely by mcv.remote.apt
@@ -80,5 +81,5 @@ def install(pkgs):
     return _install(pkgs_to_install)
 
 def update():
-    retval = subprocess.call([apt_cmd, "update"], stdout=sys.stdout)
+    retval = subprocess.call(update_cmd, stdout=sys.stdout)
     return retval

--- a/mcv/remote/apt.py
+++ b/mcv/remote/apt.py
@@ -27,3 +27,8 @@ def install(ssh, pkgs):
 
     return _install(ssh, pkgs_to_install)
 
+def update(ssh):
+    return mcv.remote.execute(
+        ssh,
+        mcv.apt.update_cmd,
+        sudo=True)


### PR DESCRIPTION
This commit adds remote `apt-get update` functionality to
`mcv.remote.apt`.  This allow us to update apt information remotely
during the bootstrap phase, rather than needing to wait until the
local phase, in case we need up-to-date info during the earlier
phase for setting up the remote execution environment.
