### PR TITLE
Ignore comment output from pip

### DIFF
--- a/mcv/pip.py
+++ b/mcv/pip.py
@@ -7,7 +7,10 @@ pip_cmd = "/usr/bin/pip"
 pip_list_cmd = [pip_cmd, 'freeze']
 
 def _status(pip_output):
-    return dict([l.split('==') for l in pip_output.split('\n') if l])
+    return dict([l.split('==')
+                 for l
+                 in pip_output.split('\n')
+                 if l and not l.startswith('#')])
 
 def status(pkgs):
     out = subprocess.check_output(pip_list_cmd).strip()

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 setup(
     name = "mcv",
-    version = "0.10.1",
+    version = "0.10.2",
     packages = find_packages(),
     install_requires = [
         'pyyaml',


### PR DESCRIPTION
pip sometimes apparently spits out debug output comments when it lists
packages in `pip freeze`.  Ignore any of these lines when trying
to figure out whether or not a package is installed.
