### PR TITLE
Enable excluding directories from creation

### DIFF
--- a/mcv/dir.py
+++ b/mcv/dir.py
@@ -99,10 +99,16 @@ def _mktree(tree):
 
     return zip(paths, opts)
 
-def mktree(tree):
+def mktree(tree, pred=lambda opts: True):
     """Given a tree, make all the directories in the tree
     recursively, with opts applied hiearchically, i.e. opts specified
     at a node also get applied to subnodes (unless later
-    overridden)"""
+    overridden)
+
+    Optionally accepts a `pred`icate function that takes
+    an options dict for each node, and returns boolean
+    whether that node should be created.
+    """
     for path, opts in _mktree(tree):
-        mcv.file.mkdir(path, opts=opts)
+        if pred(opts):
+            mcv.file.mkdir(path, opts=opts)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 setup(
     name = "mcv",
-    version = "0.14.0",
+    version = "0.15.0",
     packages = find_packages(),
     install_requires = [
         'pyyaml',


### PR DESCRIPTION
Some directories in our abstract tree we want to be able to
address/refer to, but not necessarily create when we create the tree.
This commit enables `mcv.dir.mktree` to exclude creating nodes based
on a predicate given at creation time--by default it defaults to
creating all the nodes given.
