### PR TITLE
When a CF stack is rolled back, stop waiting

### DIFF
--- a/mcv/cloudformation.py
+++ b/mcv/cloudformation.py
@@ -42,8 +42,8 @@ def get_stack_status(stack_name):
 
 def wait_for_stack_status(stack_name, desired_status, bad_status=None):
     status = get_stack_status(stack_name)
-    while (status != desired_status):
-        if (bad_status and status == bad_status):
+    while status != desired_status:
+        if bad_status and status == bad_status:
             sys.stdout.write('\n')
             sys.stdout.flush()
             return False
@@ -62,7 +62,7 @@ def wait_for_created_or_updated(verb, stack_name):
     desired_status = verb.upper() + '_COMPLETE'
     success = wait_for_stack_status(stack_name, desired_status,
                                     'ROLLBACK_COMPLETE')
-    if (not success):
+    if not success:
         print("There was a problem, and the stack has been rolled back.")
         print("See the CloudFormation event log in the AWS console " +
               "for more info")


### PR DESCRIPTION
If CloudFormation encounters a failure when creating or updating a
stack, it will rollback all the changes so that the create or update is
atomic. (This is very nice!)

This commit changes the functions that wait for a stack to be
created/updated so that they detect the rollback and stop waiting,
printing a message to the user that there was an error.
