### PR TITLE
Add Python 2.6 compatibility

### DIFF
--- a/mcv/apt.py
+++ b/mcv/apt.py
@@ -62,7 +62,7 @@ def import_key(keyserver, key_id):
 
 def _source_list_path(list_name):
     filename = list_name if list_name.endswith('list') else list_name + ".list"
-    return '/etc/apt/sources.list.d/{}'.format(filename)
+    return '/etc/apt/sources.list.d/{0}'.format(filename)
 
 
 def add_source_list(list_name, lines):

--- a/mcv/apt.py
+++ b/mcv/apt.py
@@ -17,7 +17,10 @@ def _dpkg_query_local(pkg):
     cmd = _dpkg_query_cmd(pkg)
     try:
         with open(os.devnull, 'w') as devnull:
-            output = subprocess.check_output(cmd, stderr=devnull)
+            output = subprocess.Popen(
+                    cmd,
+                    stdout=subprocess.PIPE,
+                    stderr=devnull).communicate()[0]
         return output
     except subprocess.CalledProcessError, e:
         if e.returncode == 1:  # package not installed
@@ -45,8 +48,8 @@ def _dpkg_status(dpkg_query_output):
 
 
 def key_exists(key_id, keyring='/etc/apt/trusted.gpg'):
-    out = subprocess.check_output(['gpg', '--list-keys', '--primary-keyring',
-                                  keyring])
+    command = ['gpg', '--list-keys', '--primary-keyring', keyring]
+    out = subprocess.Popen(command, stdout=subprocess.PIPE).communicate()[0]
     lines = out.split("\n")
     return any(key_id in l for l in lines)
 

--- a/mcv/apt.py
+++ b/mcv/apt.py
@@ -80,7 +80,7 @@ def rm_source_list(list_name):
 
 def status(pkgs):
     """Return the install status of the given packages."""
-    return {p: _dpkg_status(_dpkg_query_local(p)) for p in pkgs}
+    return dict((p, _dpkg_status(_dpkg_query_local(p))) for p in pkgs)
 
 
 def _install(pkgs):

--- a/mcv/aws.py
+++ b/mcv/aws.py
@@ -15,7 +15,7 @@ def has_key_pair(key_pair, require=False):
 
     if require and not success:
         print("""
-Error: unable to find key-pair '{}'.
+Error: unable to find key-pair '{0}'.
 Perhaps the key-pair does not exist, or you do not have access to it?
 (You can check this with `aws ec2 describe-key-pairs`.)
 """.strip().format(key_pair))
@@ -33,7 +33,7 @@ def has_bucket(bucket, require=False):
 
     if require and not success:
         print("""
-    Error: unable to find bucket '{}'.
+    Error: unable to find bucket '{0}'.
     Perhaps the bucket does not exist, or you do not have access to it?
     (You can check this with `aws s3api list-buckets`.)
     """.strip().format(bucket))
@@ -42,7 +42,7 @@ def has_bucket(bucket, require=False):
 
 
 def has_s3_object(bucket, path, require=False):
-    s3_obj = "s3://{}/{}".format(bucket, path.lstrip("/"))
+    s3_obj = "s3://{0}/{1}".format(bucket, path.lstrip("/"))
     with open("/dev/null", 'w') as devnull:
         cmd = [aws_cmd, 's3', 'ls', s3_obj]
         output = subprocess.check_output(cmd, stderr=devnull)
@@ -50,7 +50,7 @@ def has_s3_object(bucket, path, require=False):
 
     if require and not success:
         print("""
-Error: unable to find S3 object '{}' in bucket '{}'.
+Error: unable to find S3 object '{0}' in bucket '{1}'.
 Perhaps the bucket or file does not exist, or you do not have access to it?
 (You can check this with `aws s3api list-buckets` and `aws s3 ls S3_PATH`.)
 """.strip().format(path, bucket))

--- a/mcv/aws.py
+++ b/mcv/aws.py
@@ -26,7 +26,8 @@ Perhaps the key-pair does not exist, or you do not have access to it?
 def has_bucket(bucket, require=False):
     with open("/dev/null", 'w') as devnull:
         cmd = [aws_cmd, 's3api', 'list-buckets']
-        output = subprocess.check_output(cmd, stderr=devnull)
+        output = subprocess.Popen(
+                cmd, stderr=devnull, stdout=subprocess.PIPE).communicate()[0]
     buckets = json.loads(output)['Buckets']
     bkt_names = [bkt['Name'] for bkt in buckets]
     success = bucket in bkt_names
@@ -45,7 +46,8 @@ def has_s3_object(bucket, path, require=False):
     s3_obj = "s3://{0}/{1}".format(bucket, path.lstrip("/"))
     with open("/dev/null", 'w') as devnull:
         cmd = [aws_cmd, 's3', 'ls', s3_obj]
-        output = subprocess.check_output(cmd, stderr=devnull)
+        output = subprocess.Popen(
+                cmd, stderr=devnull, stdout=subprocess.PIPE).communicate()[0]
     success = len(output) > 0
 
     if require and not success:

--- a/mcv/cloudformation.py
+++ b/mcv/cloudformation.py
@@ -29,7 +29,8 @@ def check_template(template, verbose=False):
     # The command will output to STDOUT if successful, and STDERR if
     # unsuccessful, but we want neither output to be seen by the user.
     try:
-        subprocess.check_output(cmd)
+        with open('/dev/null', 'w') as devnull:
+            subprocess.call(cmd, stdout=devnull, stderr=devnull)
         return True
     except subprocess.CalledProcessError:
         return False
@@ -38,7 +39,8 @@ def check_template(template, verbose=False):
 def get_stack_status(stack_name):
     query = "Stacks[?StackName==`" + stack_name + "`].StackStatus | [0]"
     cmd = ['aws', 'cloudformation', 'describe-stacks', "--query", query]
-    return subprocess.check_output(cmd).strip().strip('"')
+    return subprocess.Popen(
+            cmd, stdout=subprocess.PIPE).communicate()[0].strip().strip('"')
 
 
 def wait_for_stack_status(stack_name, desired_status, bad_status=None):
@@ -78,7 +80,7 @@ def wait_for_destroyed(stack_name):
 def get_current_params(stack_name):
     command = ["aws", "cloudformation", "describe-stacks",
                "--stack-name", stack_name]
-    output = subprocess.check_output(command)
+    output = subprocess.Popen(command, stdout=subprocess.PIPE).communicate()[0]
     params = json.loads(output)['Stacks'][0]['Parameters']
     return dict((p['ParameterKey'], p['ParameterValue']) for p in params)
 

--- a/mcv/cloudformation.py
+++ b/mcv/cloudformation.py
@@ -80,7 +80,7 @@ def get_current_params(stack_name):
                "--stack-name", stack_name]
     output = subprocess.check_output(command)
     params = json.loads(output)['Stacks'][0]['Parameters']
-    return {p['ParameterKey']: p['ParameterValue'] for p in params}
+    return dict((p['ParameterKey'], p['ParameterValue']) for p in params)
 
 
 def load_params(stack_name, params):

--- a/mcv/cloudformation.py
+++ b/mcv/cloudformation.py
@@ -12,7 +12,7 @@ def _make_params(params):
     list of words ready to be passed to an `aws cloudformation` command,
     including the `--parameters` word at the beginning."""
     return ["--parameters"] + \
-           ["ParameterKey={},ParameterValue={}".format(k, params[k])
+           ["ParameterKey={0},ParameterValue={1}".format(k, params[k])
             for k in params]
 
 

--- a/mcv/env.py
+++ b/mcv/env.py
@@ -12,7 +12,7 @@ def parse_environment_file():
         raw_lines = efile.readlines()
         lines = [re.sub(r'#.*$', '', line).strip() for line in raw_lines]
         matches = [re.match(r'^(\w+)=(.*)$', line) for line in lines]
-        return {m.group(1): m.group(2) for m in matches if m}
+        return dict((m.group(1), m.group(2)) for m in matches if m)
 
 
 def append_env_setting(name, value):

--- a/mcv/filesystem.py
+++ b/mcv/filesystem.py
@@ -43,7 +43,9 @@ def mkfs(dev, dst_fstype, opts, force=False, verbose='error'):
         if out != 0:
             src_fstype = None
         else:
-            out = subprocess.check_output(cmd, stderr=sys.stderr)
+            out = subprocess.Popen(
+                    cmd, stdout=subprocess.PIPE,
+                    stderr=sys.stderr).communicate()[0]
             src_fstype = out.strip()
 
     if src_fstype == dst_fstype:

--- a/mcv/git.py
+++ b/mcv/git.py
@@ -23,7 +23,7 @@ def git_ssh_env(key_path, opts={}):
     and a dictionary opts={} which contains SSH -o options,
     as explained in man pages for ssh_config(5)
     """
-    opt_pairs = [['-o', "{}={}".format(k, v)] for k, v in opts.iteritems()]
+    opt_pairs = [['-o', "{0}={1}".format(k, v)] for k, v in opts.iteritems()]
     opts_chained = [o for o in itertools.chain(*opt_pairs)]
 
     temp_ssh_script = lines_to_string(

--- a/mcv/git.py
+++ b/mcv/git.py
@@ -79,7 +79,10 @@ def fetch(repo_path, key_path, ssh_opts={}):
 
 
 def _show_ref(repo_path):
-    return subprocess.check_output(['git', 'show-ref'], cwd=repo_path)
+    return subprocess.Popen(
+            ['git', 'show-ref'],
+            stdout=subprocess.PIPE,
+            cwd=repo_path).communicate()[0]
 
 
 def _refs(show_ref_output):
@@ -109,7 +112,11 @@ def export(repo_path, deploy_path, rev, opts={}):
 
         cmd_tmpl = "git archive {rev} | tar -x -C {dir}"
         cmd = cmd_tmpl.format(rev=rev, dir=deploy_path)
-        out = subprocess.check_output(cmd, cwd=repo_path, shell=True)
+        out = subprocess.Popen(
+                cmd,
+                cwd=repo_path,
+                shell=True,
+                stdout=subprocess.PIPE).communicate()[0]
         mcv.file.ch_ext(
             deploy_path,
             mcv.util.merge_dicts(

--- a/mcv/pip.py
+++ b/mcv/pip.py
@@ -19,7 +19,7 @@ def _status(pip_output):
 def status(pkgs):
     out = subprocess.check_output([_pip_cmd(), 'freeze']).strip()
     installed = _status(out)
-    return {p: installed.get(p) for p in pkgs}
+    return dict((p, installed.get(p)) for p in pkgs)
 
 
 def _install_cmd(pkgs, upgrade=False):

--- a/mcv/pip.py
+++ b/mcv/pip.py
@@ -17,7 +17,9 @@ def _status(pip_output):
 
 
 def status(pkgs):
-    out = subprocess.check_output([_pip_cmd(), 'freeze']).strip()
+    cmd = [_pip_cmd(), 'freeze']
+    out = subprocess.Popen(
+            cmd, stdout=subprocess.PIPE).communicate()[0].strip()
     installed = _status(out)
     return dict((p, installed.get(p)) for p in pkgs)
 

--- a/mcv/remote/__init__.py
+++ b/mcv/remote/__init__.py
@@ -154,7 +154,7 @@ def deploy(ssh, local_src, remote_dst, sudo=False, excludes=['.git']):
 
     sys.stderr.write("Tarring with: " + str(cmd) + "\n")
 
-    out = subprocess.check_output(cmd)
+    out = subprocess.Popen(cmd, stdout=subprocess.PIPE).communicate()[0]
 
     ssh_stdin, ssh_stdout, ssh_stderr = ssh.exec_command('mktemp')
     remote_temppath = ssh_stdout.read().strip()

--- a/mcv/remote/__init__.py
+++ b/mcv/remote/__init__.py
@@ -89,7 +89,7 @@ def execute(ssh, cmd, sudo=False, stdout=sys.stdout, stderr=sys.stderr):
     # `subprocess`-style.  Handle it nicely.
     cmd_string = cmd if isinstance(cmd, basestring) else ' '.join(cmd)
 
-    final_cmd = '/usr/bin/sudo /bin/sh -c {}'.format(
+    final_cmd = '/usr/bin/sudo /bin/sh -c {0}'.format(
         pipes.quote(cmd_string)) if sudo else cmd_string
 
     bufsize = -1
@@ -130,7 +130,7 @@ def _copy(ssh, local_src, remote_dst, sudo=False):
         remote_temppath = ssh_stdout.read().strip()
         with sftp_connection(ssh) as sftp:
             sftp.put(local_src, remote_temppath)
-        cmd = '/usr/bin/sudo mv {} {}'.format(remote_temppath, remote_dst)
+        cmd = '/usr/bin/sudo mv {0} {1}'.format(remote_temppath, remote_dst)
         print cmd
         ssh_stdin, ssh_stdout, ssh_stderr = ssh.exec_command(cmd)
     else:
@@ -159,16 +159,16 @@ def deploy(ssh, local_src, remote_dst, sudo=False, excludes=['.git']):
     ssh_stdin, ssh_stdout, ssh_stderr = ssh.exec_command('mktemp')
     remote_temppath = ssh_stdout.read().strip()
 
-    sys.stderr.write("Copying tarball to {}\n".format(remote_temppath))
+    sys.stderr.write("Copying tarball to {0}\n".format(remote_temppath))
 
     _copy(ssh, temp.name, remote_temppath, sudo=False)
 
     sys.stderr.write("Making target directory\n")
-    mkdir_cmd = 'mkdir -p {}'.format(remote_dst)
+    mkdir_cmd = 'mkdir -p {0}'.format(remote_dst)
 
     out, err, exit = execute(ssh, mkdir_cmd, sudo=sudo)
 
-    tar_cmd = 'tar -xvf {} -C {}'.format(remote_temppath, remote_dst)
+    tar_cmd = 'tar -xvf {0} -C {1}'.format(remote_temppath, remote_dst)
 
     sys.stderr.write("Extracting tar to target directory\n")
 

--- a/mcv/remote/apt.py
+++ b/mcv/remote/apt.py
@@ -12,7 +12,7 @@ def _status(ssh, pkg):
 
 
 def status(ssh, pkgs):
-    return {p: _status(ssh, p) for p in pkgs}
+    return dict((p, _status(ssh, p)) for p in pkgs)
 
 
 def _install(ssh, pkgs):

--- a/mcv/remote/pip.py
+++ b/mcv/remote/pip.py
@@ -10,7 +10,7 @@ pip_cmd = "/usr/bin/pip"
 def status(ssh, pkgs):
     out, err, exit = mcv.remote.execute(ssh, mcv.pip.pip_list_cmd)
     installed = mcv.pip._status(out)
-    return {p: installed.get(p) for p in pkgs}
+    return dict((p, installed.get(p)) for p in pkgs)
 
 
 def install(ssh, pkgs, sudo=False, upgrade=False):

--- a/mcv/remote/vagrant.py
+++ b/mcv/remote/vagrant.py
@@ -7,7 +7,8 @@ import paramiko
 
 
 def _get_ssh_config():
-    return subprocess.check_output(['vagrant', 'ssh-config'])
+    return subprocess.Popen(
+            ['vagrant', 'ssh-config'], stdout=subprocess.PIPE).communicate()[0]
 
 
 def _parse_ssh_config(vagrant_ssh_output):

--- a/mcv/upstart.py
+++ b/mcv/upstart.py
@@ -4,7 +4,8 @@ import re
 
 def status(service_name):
     """Query Upstart status"""
-    output = subprocess.check_output(['status', service_name])
+    output = subprocess.Popen(
+            ['status', service_name], stdout=subprocess.PIPE).communicate()[0]
     re_tmpl = '(?P<service>\S+) (?P<status>[\w/]+)(, process (?P<proc>\d+))?'
     r = re.compile(re_tmpl)
     m = r.match(output)

--- a/mcv/user.py
+++ b/mcv/user.py
@@ -12,9 +12,9 @@ def ent_passwd(username):
         field_keys = ['user', 'pass', 'uid', 'gid', 'comment', 'home', 'shell']
         field_types = [str, str, int, int, str, str, str]
         field_values = out.split(':')
-        return {k: t(v)
-                for k, t, v
-                in zip(field_keys, field_types, field_values)}
+        return dict((k, t(v))
+                    for k, t, v
+                    in zip(field_keys, field_types, field_values))
     else:
         return None
 
@@ -56,7 +56,7 @@ def mod(username, opt_dict):
     if len(opt_dict) == 0:
         return
 
-    cmd_args = {"--" + k: join_arg(v) for k, v in opt_dict.iteritems()}
+    cmd_args = dict(("--" + k, join_arg(v)) for k, v in opt_dict.iteritems())
     opts = list(itertools.chain(*cmd_args.iteritems()))
     cmd = ["usermod"] + opts + [username]
     retval = subprocess.call(cmd, stdout=sys.stdout)

--- a/mcv/user.py
+++ b/mcv/user.py
@@ -5,9 +5,9 @@ import os
 
 
 def ent_passwd(username):
-    out = subprocess.\
-        check_output(["/usr/bin/getent", "passwd", username]).\
-        strip()
+    command = ["/usr/bin/getent", "passwd", username]
+    out = subprocess.Popen(command, stdout=subprocess.PIPE).communicate()[0].\
+            strip()
     if bool(out):
         field_keys = ['user', 'pass', 'uid', 'gid', 'comment', 'home', 'shell']
         field_types = [str, str, int, int, str, str, str]

--- a/mcv/util.py
+++ b/mcv/util.py
@@ -4,7 +4,7 @@ import itertools
 
 
 def select_keys(d, keys):
-    return {k: d.get(k) for k in keys if d.get(k)}
+    return dict((k, d.get(k)) for k in keys if d.get(k))
 
 
 def merge_dicts(*ds):


### PR DESCRIPTION
The Amazon Linux AMIs have Python 2.6 (.9), not Python 2.7, installed (even the latest versions!). As a result, the Python 2.7 features in `mcv` cause it to be unusable in a CloudFormation stack.

This PR aims to make the code compatible with Python 2.6. Unfortunately, it's difficult for me (with my relative ignorance of the Python ecosystem) to be confident that the code will be fully functional on Python 2.6. I am confident that the code compiles in Python 2.6.9, but that doesn't mean there won't be any issues at run-time.

Also unfortunately, the CloudInit package system installs python packages with `easy_install`, which of course only works for publicly released versions of packages. So I'm not sure how to test this without actually cutting a new version of `mcv`, which isn't ideal. @elliot42 - any ideas? I'll keep trying to figure it out (and will reply here if I do), but just thought you might know something off the top of your head.