### PR TITLE
Enable retrieving build artifacts from CircleCI

### DIFF
--- a/mcv/circleci.py
+++ b/mcv/circleci.py
@@ -1,0 +1,25 @@
+"""CircleCI"""
+
+import mcv.http
+import requests
+
+
+def artifacts(token, username, project, build_num):
+    """Retrieve a list of build artifacts"""
+
+    url = "/".join([
+        "https://circleci.com/api/v1/project",
+        username,
+        project,
+        str(build_num),
+        "artifacts"])
+
+    r = requests.get(
+        url,
+        params={'circle-token': token},
+        headers={'accept': 'application/json'})
+    return r.json()
+
+
+def get_file(token, url):
+    return mcv.http.get_file(url, {'circle-token': token})

--- a/mcv/http.py
+++ b/mcv/http.py
@@ -1,0 +1,14 @@
+"""HTTP"""
+
+import requests
+import tempfile
+
+
+def get_file(url, params={}):
+    local = tempfile.TemporaryFile()
+    r = requests.get(url, stream=True, params=params)
+    with open(local.name, 'wb') as f:
+        for chunk in r.iter_content(chunk_size=256 * 1024):
+            if chunk:  # filter out keep-alive new chunks
+                f.write(chunk)
+    return local

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 setup(
     name = "mcv",
-    version = "0.18.0",
+    version = "0.19.0",
     packages = find_packages(),
     install_requires = [
         'pyyaml',


### PR DESCRIPTION
This commit adds utility functions for downloading build
artifacts from CircleCI.  This allows anybody to leverage
CircleCI's handy build automation workflows.
