### PR TITLE
Add archive downloader from GitHub

### DIFF
--- a/mcv/circleci.py
+++ b/mcv/circleci.py
@@ -22,4 +22,4 @@ def artifacts(token, username, project, build_num):
 
 
 def get_file(token, url):
-    return mcv.http.get_file(url, {'circle-token': token})
+    return mcv.http.get_file(url, params={'circle-token': token})

--- a/mcv/github.py
+++ b/mcv/github.py
@@ -1,6 +1,35 @@
 """GitHub utility functions"""
 
+from __future__ import absolute_import
+
+import mcv.http
+import tarfile
+
 
 def keys_uri(username):
     template = 'https://github.com/{username}.keys'
     return template.format(username=username)
+
+
+def get_archive_tarball(owner, repo, rev, **get_kwargs):
+    """**get_kwargs: same keyword args used by mcv.http.get_file,
+    which are the same as requests.get"""
+
+    archive_url = "/".join([
+        "https://github.com",
+        owner,
+        repo,
+        "archive",
+        rev + ".tar.gz"])
+
+    response, f = mcv.http.get_file(archive_url, **get_kwargs)
+    return tarfile.open(fileobj=f, mode='r:gz') if f else None
+
+
+def extract_tarball(tarfile, path):
+    """Specialized tarball extractor that strips the first
+    directory component from the tarball that GitHub puts in."""
+    for tarinfo in tarfile.getmembers():
+        subpath_ix = tarinfo.name.find("/")
+        tarinfo.name = tarinfo.name[subpath_ix + 1:]
+        tarfile.extract(tarinfo, path)

--- a/mcv/http.py
+++ b/mcv/http.py
@@ -4,11 +4,17 @@ import requests
 import tempfile
 
 
-def get_file(url, params={}):
-    local = tempfile.TemporaryFile()
-    r = requests.get(url, stream=True, params=params)
-    with open(local.name, 'wb') as f:
-        for chunk in r.iter_content(chunk_size=256 * 1024):
-            if chunk:  # filter out keep-alive new chunks
-                f.write(chunk)
-    return local
+def get_file(url, **kwargs):
+    local = tempfile.NamedTemporaryFile()
+    kwargs['stream'] = True
+    r = requests.get(url, **kwargs)
+
+    if r.status_code == 200:
+        with open(local.name, 'wb') as f:
+            for chunk in r.iter_content(chunk_size=256 * 1024):
+                if chunk:  # filter out keep-alive new chunks
+                    f.write(chunk)
+    else:
+        local = None
+
+    return [r, local]

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 setup(
     name = "mcv",
-    version = "0.19.1",
+    version = "0.20.0",
     packages = find_packages(),
     install_requires = [
         'pyyaml',


### PR DESCRIPTION
This commit enables `mcv` to download archive tarballs of GitHub
repositories, and extract them.  This is a super convenient way to get
Git archives at a desired rev with relatively fewer moving pieces
than, for example, checking out and then archiving.
