### PR TITLE
Enable installing pip packages from GitHubf

### DIFF
--- a/mcv/github.py
+++ b/mcv/github.py
@@ -2,6 +2,7 @@
 
 from __future__ import absolute_import
 
+import mcv.pip
 import mcv.file
 import mcv.http
 import subprocess
@@ -13,17 +14,18 @@ def keys_uri(username):
     return template.format(username=username)
 
 
+def _archive_url(owner, repo, rev, auth=None):
+    auth_str = ":".join(auth) + "@" if auth else ""
+    fmt = "https://{}github.com/{}/{}/archive/{}.tar.gz"
+
+    return fmt.format(auth_str, owner, repo, rev)
+
+
 def get_archive_tarball(owner, repo, rev, **get_kwargs):
     """**get_kwargs: same keyword args used by mcv.http.get_file,
     which are the same as requests.get"""
 
-    archive_url = "/".join([
-        "https://github.com",
-        owner,
-        repo,
-        "archive",
-        rev + ".tar.gz"])
-
+    archive_url = _archive_url(owner, repo, rev)
     response, f = mcv.http.get_file(archive_url, **get_kwargs)
     return tarfile.open(fileobj=f, mode='r:gz') if f else None
 
@@ -36,6 +38,11 @@ def extract_tarball(tarfile, path):
          tarfile.name,
          '--strip-components', '1',
          '-C', path])
+
+
+def pip_install(user, repo, rev, oauth):
+    url = _archive_url(user, repo, rev, auth=(oauth, 'x-oauth-basic'))
+    mcv.pip.install([url])
 
 
 def deploy_repo(user, repo, rev, path, oauth):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 setup(
     name = "mcv",
-    version = "0.22.0",
+    version = "0.23.0",
     packages = find_packages(),
     install_requires = [
         'pyyaml',

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1,0 +1,15 @@
+import mcv.github
+from nose.tools import eq_
+
+
+def test__archive_url_no_auth():
+    eq_(mcv.github._archive_url('myuser', 'myrepo', 'master'),
+        "https://github.com/myuser/myrepo/archive/master.tar.gz")
+
+
+def test__archive_url_auth():
+    eq_(mcv.github._archive_url('myuser',
+                                'myrepo',
+                                'master',
+                                auth=('me', '12345')),
+        "https://me:12345@github.com/myuser/myrepo/archive/master.tar.gz")


### PR DESCRIPTION
This commit makes it so that MCV can install `pip` packages directly
from GitHub archive specifiers, including private repos via GitHub
oauth tokens.
