### PR TITLE
Allow Leiningen to run as `root`

### DIFF
--- a/mcv/clojure.py
+++ b/mcv/clojure.py
@@ -6,9 +6,14 @@ import re
 
 def _uberjar(project_path):
     lein_cmd = distutils.spawn.find_executable('lein')
+
+    env = os.environ.copy()
+    env['LEIN_ROOT'] = 'yes'  # Allow Leiningen to run as root
+
     p = subprocess.Popen(
         [lein_cmd, "uberjar"],
         cwd=project_path,
+        env=env,
         stdout=subprocess.PIPE)
     output, output_err = p.communicate()
     return output

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 setup(
     name = "mcv",
-    version = "0.23.0",
+    version = "0.23.1",
     packages = find_packages(),
     install_requires = [
         'pyyaml',


### PR DESCRIPTION
If you don't include this, it'll pause silently if you're trying to
run as `root`.
