### PR TITLE
mcv.remote.deploy - disable tar verbosity

### DIFF
--- a/mcv/remote/__init__.py
+++ b/mcv/remote/__init__.py
@@ -148,7 +148,7 @@ def deploy(ssh, local_src, remote_dst, sudo=False, excludes=['.git']):
     temp = tempfile.NamedTemporaryFile()
     exclude_pairs = [['--exclude', e] for e in excludes]
 
-    cmd = ['/bin/tar', '-cvf', temp.name] + \
+    cmd = ['/bin/tar', '-cf', temp.name] + \
           [e for e in itertools.chain(*exclude_pairs)] + \
           [local_src]
 
@@ -168,7 +168,7 @@ def deploy(ssh, local_src, remote_dst, sudo=False, excludes=['.git']):
 
     out, err, exit = execute(ssh, mkdir_cmd, sudo=sudo)
 
-    tar_cmd = 'tar -xvf {0} -C {1}'.format(remote_temppath, remote_dst)
+    tar_cmd = 'tar -xf {0} -C {1}'.format(remote_temppath, remote_dst)
 
     sys.stderr.write("Extracting tar to target directory\n")
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 setup(
     name = "mcv",
-    version = "0.28.0",
+    version = "0.29.0",
     packages = find_packages(),
     install_requires = [
         'pyyaml',


### PR DESCRIPTION
This lists every file as it's compressed/decompressed, which is useful
during debugging and lib building but creates a ton of noise during
production usage. We can cut it with zero loss and re-add under a
verbosity config flag later if needed.