### PR TITLE
Add mcv.hostname

### DIFF
--- a/mcv/hostname.py
+++ b/mcv/hostname.py
@@ -1,0 +1,29 @@
+import os
+
+HOSTNAME_FILE = '/etc/hostname'
+HOSTS_FILE = '/etc/hosts'
+
+
+def _splice_alias(alias, line):
+    """If line is an alias for localhost, append <alias>
+    (if not already present)"""
+    vs = line.split(' ')
+    if vs[0] == '127.0.0.1' and alias not in vs[1:]:
+        vs.append(alias)
+        return ' '.join(vs)
+    else:
+        return line
+
+
+def set_hostname(hostname):
+    """Set the system hostname to <hostname> and add a
+    corresponding entry to /etc/hosts"""
+    os.system('hostname ' + hostname)
+    with open(HOSTNAME_FILE, 'w') as f:
+        f.write(hostname)
+    with open(HOSTS_FILE, 'r') as f:
+        stripped_lines = [l.rstrip() for l in f.readlines()]
+        spliced_lines = [_splice_alias(hostname, l) for l in stripped_lines]
+        new_contents = "\n".join(spliced_lines)
+    with open(HOSTS_FILE, 'w') as f:
+        f.write(new_contents)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 setup(
     name = "mcv",
-    version = "0.29.0",
+    version = "0.30.0",
     packages = find_packages(),
     install_requires = [
         'pyyaml',

--- a/tests/test_hostname.py
+++ b/tests/test_hostname.py
@@ -1,0 +1,12 @@
+import mcv.hostname
+from nose.tools import eq_
+
+
+def test__splice_alias():
+    l1 = '255.255.255.255    broadcasthost'
+    l2 = '127.0.0.1 localhost'
+    l3 = '127.0.0.1 localhost wozzle'
+    eq_(mcv.hostname._splice_alias('wozzle', l1), l1)
+    eq_(mcv.hostname._splice_alias('wozzle', l2),
+        '127.0.0.1 localhost wozzle')
+    eq_(mcv.hostname._splice_alias('wozzle', l3), l3)


### PR DESCRIPTION
Add a utility to set the system hostname, in a manner that should
survive restarts and modifies /etc/hosts to prevent unknown host
warnings