### PR TITLE
Turn on absolute import everywhere

### DIFF
--- a/mcv/apt.py
+++ b/mcv/apt.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import subprocess
 import sys
 import re

--- a/mcv/clojure.py
+++ b/mcv/clojure.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import subprocess
 import distutils.spawn
 import os

--- a/mcv/cloudformation.py
+++ b/mcv/cloudformation.py
@@ -1,5 +1,7 @@
 """AWS CloudFormation utilities"""
 
+from __future__ import absolute_import
+
 import os.path
 import subprocess
 import sys

--- a/mcv/dir.py
+++ b/mcv/dir.py
@@ -10,6 +10,8 @@ This module should mostly expose things in terms of `path`s, not
 level  if necessary.
 """
 
+from __future__ import absolute_import
+
 import treant
 import os
 import mcv.file

--- a/mcv/env.py
+++ b/mcv/env.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import re
 from contextlib import contextmanager
 import os

--- a/mcv/filesystem.py
+++ b/mcv/filesystem.py
@@ -3,6 +3,8 @@
 Credit to Alexander Bulimov <lazywolf0@gmail.com> and Seth Vidal (RIP)
 for writing the Ansible modules on which this is based."""
 
+from __future__ import absolute_import
+
 import sys
 import os
 import subprocess

--- a/mcv/git.py
+++ b/mcv/git.py
@@ -1,5 +1,7 @@
 """Git-related utilities"""
 
+from __future__ import absolute_import
+
 import os
 import mcv.file
 import sys

--- a/mcv/pip.py
+++ b/mcv/pip.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import subprocess
 import sys
 import re

--- a/mcv/remote/pip.py
+++ b/mcv/remote/pip.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import mcv.pip
 import mcv.remote
 import sys

--- a/mcv/sudo.py
+++ b/mcv/sudo.py
@@ -5,6 +5,8 @@ to filter out old rules from the sudoers file, and add new
 rules by templating a rules file.
 """
 
+from __future__ import absolute_import
+
 import re
 import os
 import mcv.file

--- a/mcv/user.py
+++ b/mcv/user.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import subprocess
 import sys
 import itertools


### PR DESCRIPTION
Now that we have an mcv.os module, we need absolute import turned on
everywhere we're trying to import top-level `os` module, instead of
`mcv.os`.  This was supposed to be resolved in Python 2.7, but _is
not_--manually enabling absolute imports is still required in 2.7,
though it's finally fixed in 3.

(And for better or worse, the default version shipping on Ubuntu
etc. is still 2 not 3).