### PR TITLE
Update Patchwork module to use new dpkg query

### DIFF
--- a/mcv/patchwork.py
+++ b/mcv/patchwork.py
@@ -107,7 +107,7 @@ def gather_packages():
     """
     dpkg_query_cmd = [
         "/usr/bin/dpkg-query", "-W",
-        "-f", "${Status}\t${Package}\t${Version}\n",
+        "-f", "${Status}\t${Package}\t${source:Version}\n",
     ]
 
     process = subprocess.Popen(dpkg_query_cmd, stdout=subprocess.PIPE)


### PR DESCRIPTION
The dpkg query changed upstream about how it needs to query
specifically what versions of what packages you have installed.